### PR TITLE
Increased nexus staging numberOfRetries and delayBetweenRetriesInMillis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "dev.fuelyour"
-version = "0.0.3"
+version = "0.0.4"
 val projectDescription = "Core libraries used by microservices created from " +
     "the vertx-kuickstart template"
 description = projectDescription
@@ -150,4 +150,6 @@ if (rootProject.extra["isReleaseVersion"] as Boolean) {
 nexusStaging {
     username = System.getenv("ossrhUsername")
     password = System.getenv("ossrhPassword")
+    numberOfRetries = 60
+    delayBetweenRetriesInMillis = 5000
 }


### PR DESCRIPTION
Closing and releasing from nexus staging was timing out. Upped these
numbers based on similar numbers that I saw in the graphql-kotlin
project's build.gradle.kts file.