### PR TITLE
Made an error clearer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "dev.fuelyour"
-version = "0.0.8"
+version = "0.0.9"
 val projectDescription = "Core libraries used by microservices created from " +
     "the vertx-kuickstart template"
 description = projectDescription


### PR DESCRIPTION
When the name of a function parameter doesn't match up with the openpi specification, a clearer error message will be given.